### PR TITLE
Add Lucas O'Neil to acapy-committers team

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,7 @@ teams:
       - ff137
       - thiagoromanos
       - PatStLouis
+      - loneil
   - name: acapy-contributors
     maintainers:
       - swcurran


### PR DESCRIPTION
We'd like to add Lucas O'Neil (@loneil) to acapy-committers team.  This will allow him to maintain acapy projects, which will provide him with the ability to do things like merge PRs.  Please vote by responding with a 👍 or 👎.

Tagging all of the existing acapy-committers here to vote.
@swcurran
@TelegramSam
@andrewwhitehead
@TimoGlastra
@WadeBarnes
@amanji
@chumbert
@dbluhm
@esune
@ianco
@jamshale
@ff137
@thiagoromanos
@PatStLouis