### PR TITLE
chore: update bifold maintainers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -71,10 +71,11 @@ teams:
     maintainers:
       - jleach
     members:
+      - al-rosenthal
       - amanji
       - bryce-mcmath
       - cvarjao
-      - wadeking98
+      - fc-santos
       - jcdrouin21
       - MosCD3
       - thiagoromanos
@@ -210,17 +211,17 @@ teams:
       - darrellodonnell
   - name: sd-jwt-js-admin
     maintainers:
-    - cre8
+      - cre8
     members:
-    - lukasjhan
+      - lukasjhan
   - name: sd-jwt-js-maintainers
     maintainers:
-    - cre8
+      - cre8
     members:
-    - aceshim
-    - berendsliedrecht
-    - lukasjhan
-    - zustkeeper
+      - aceshim
+      - berendsliedrecht
+      - lukasjhan
+      - zustkeeper
   - name: tac
     maintainers:
       - tkuhrt


### PR DESCRIPTION
* **Maintainer Update:** We're updating the members of the `bifold-wallet-maintainers` project, as discussed on today's Bifold community call (see link for details).
    * [Bifold community call](https://lf-openwallet-foundation.atlassian.net/wiki/spaces/BIFOLD/pages/71663623/2025-01-14+User+Group)
* **Documentation Formatting:** I've also improved the indentation in the `sd-jwt-js-admin` documentation to be consistent with the rest of the project.