### PR TITLE
docs: update bifold wallet governance

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -66,13 +66,17 @@ teams:
   - name: architecture-sig-maintainers
     maintainers:
       - tkuhrt
+  - name: bifold-wallet-admins
+    maintainers:
+      - jleach
+      - cvarjao
   - name: bifold-wallet-maintainers
     maintainers:
       - jleach
+      - bryce-mcmath
     members:
       - al-rosenthal
       - amanji
-      - bryce-mcmath
       - cvarjao
       - fc-santos
       - jcdrouin21
@@ -288,6 +292,7 @@ repositories:
     visibility: public
   - name: bifold-wallet
     teams:
+      bifold-wallet-admins: admin
       bifold-wallet-maintainers: maintain
     visibility: public
   - name: credo-ts
@@ -347,6 +352,7 @@ repositories:
     visibility: public
   - name: owl-mobile-wallet-test-harness
     teams:
+      bifold-wallet-admins: admin
       bifold-wallet-maintainers: maintain
       owl-mobile-wallet-test-harness-admins: admin
       owl-mobile-wallet-test-harness-committers: maintain


### PR DESCRIPTION
As per @ryjones request, I have updated the bifold-wallet governance with an admin team, and added that admin team to both the bifold-wallet grouping and the owl-mobile-wallet-test-harness as Bifold / BC Wallet are the main, and maybe only, consumers of it and the only other maintainer / admin, nodlesh (Sheldon Regular), involvement has been paused for the time being