### PR TITLE
Correct the teams that maintain the didcomm-mediator-socketdock repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -328,10 +328,9 @@ repositories:
     visibility: public
   - name: didcomm-mediator-socketdock
     teams:
-      credo-admins: admin
-      credo-maintainers: maintain
-      didcomm-mediator-credo-maintainers: maintain
-      didcomm-mediator-credo-admin: admin
+      didcomm-admins: admin
+      didcomm-committers: maintain
+      didcomm-contributors: read
     visibility: public
   - name: digital-wallet-and-agent-overviews-sig
     teams:


### PR DESCRIPTION
Somewhere along the lines the Maintainers for the `didcomm-mediator-socketdock` repo where set to the wrong group of teams.  This updates the list to the same maintainers as for the `didcomm-mediator` repo.

In the future we might want to add the current maintainer teams back, or have teams specific to the `didcomm-mediator-socketdock` repo, but for now, this should be sufficient.

FYI : @cjhowland, @TheTechmage
