### PR TITLE
Add BCGov members to didcomm-mediator-credo-maintainers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -111,6 +111,11 @@ teams:
       - sairanjit
       - genaris
       - GHkrishna
+      - bryce-mcmath
+      - al-rosenthal
+      - esune
+      - jamshale
+      - loneil
   - name: didcomm-admins
     maintainers:
       - dbluhm
@@ -325,6 +330,7 @@ repositories:
       credo-maintainers: maintain
       didcomm-mediator-credo-maintainers: maintain
       didcomm-mediator-credo-admin: admin
+      didcomm-committers: maintain
     visibility: public
   - name: didcomm-mediator-socketdock
     teams:

--- a/config.yaml
+++ b/config.yaml
@@ -331,7 +331,7 @@ repositories:
       credo-maintainers: maintain
       didcomm-mediator-credo-maintainers: maintain
       didcomm-mediator-credo-admin: admin
-      didcomm-committers: maintain
+      didcomm-committers: write
     visibility: public
   - name: didcomm-mediator-socketdock
     teams:

--- a/config.yaml
+++ b/config.yaml
@@ -116,6 +116,7 @@ teams:
       - esune
       - jamshale
       - loneil
+      - cvarjao
   - name: didcomm-admins
     maintainers:
       - dbluhm


### PR DESCRIPTION
Add BCGov members to maintainer list for `didcomm-mediator-credo-maintainers`.

Question: would it make sense to consolidate maintainer/committer memberships of `didcomm-mediator-service` and `didcomm-mediator-credo` as they deal with the same challenge in two tech stacks (Python and Typescript)?