### PR TITLE
Create new OWF helm-charts repo and assign initial admins

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -154,6 +154,13 @@ teams:
   - name: digital-wallet-and-agent-overviews-sig-admins
     maintainers:
       - cre8
+  - name: helm-charts-admins
+    maintainers:
+      - esune
+    members:
+      - WadeBarnes
+      - swcurran
+      - i5okie
   - name: lf-employees
     maintainers:
       - ryjones
@@ -347,6 +354,11 @@ repositories:
   - name: governance
     teams:
       tac: maintain
+    visibility: public
+  - name: helm-charts
+    teams:
+      tac: maintain
+      helm-charts-admins: admin
     visibility: public
   - name: openwallet-foundation-landscape
     visibility: private


### PR DESCRIPTION
Request to create a new OWF repo "helm-charts" and assign the initial admins of the repo.  This was discussed at the [2025-04-30](https://tac.openwallet.foundation/meetings/2025/2025-04-30/) and 2025-05-14 (minutes not yet posted) and it was agreed that we would create an OWF wide "helm-charts" repo with the team from BC Gov taking the lead at populating the repo with documentation for both users of Charts and projects on how to contribute Helm Charts for their project. This is the typical way that Helm Charts are published -- in a repo at the (GitHub) organizational level.

As discussed, the Maintainers role will be lightweight -- verifying that PRs contribute OWF project Helm Charts to the repo, and as needed, verifying with the project maintainers about the contributor and contribution. The maintainers will not verify the content of the Charts, leaving that to the projects.

I've left the TAC as maintainers on the project as they can be a fallback in processing PRs, but don't expect they will be needed.

Other maintainers from other projects are welome. The initial maintainers are from the ACA-Py community who built the initial Helm Chart to go into the repo -- one for ACA-Py currently in the ACA-Py repo. Projects don't need to have a maintainer in this project to contribute, but it would be good to get other Helm Chart experts from the community helping.

Once in place, we'll invite other projects to create and contribute Helm Charts.

Questions? Ask away!

I'm not sure if the merging of this PR will automagically create the new repo, or if other steps will be needed.
