### PR TITLE
Added gavinok to acapy-committers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,7 @@ teams:
       - thiagoromanos
       - PatStLouis
       - loneil
+      - Gavinok
   - name: acapy-contributors
     maintainers:
       - swcurran


### PR DESCRIPTION
Adding @Gavinok to `acapy-committers` group to allow him to complete work on acapy, vc-authn and endorser projects.

@swcurran @jamshale @WadeBarnes @loneil 