### PR TITLE
chore: add Mac Deluca to bifold-wallet maintainers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -89,6 +89,7 @@ teams:
       - cvarjao
       - fc-santos
       - jcdrouin21
+      - MacDeluca
       - MosCD3
       - thiagoromanos
   - name: bots


### PR DESCRIPTION
@MacDeluca is a great BC Gov developer who has been on the project for many months now and has passed the 5+ PRs threshold, so we would now like to add him as a maintainer to the Bifold project

