### PR TITLE
Add credo-ts-didcomm-ext

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -409,6 +409,12 @@ repositories:
       credo-maintainers: maintain
       security-managers: read
     visibility: public
+  - name: credo-ts-didcomm-ext
+    teams:
+      credo-admins: admin
+      credo-maintainers: maintain
+      security-managers: read
+    visibility: public
   - name: didcomm-mediator-service
     teams:
       didcomm-admins: admin


### PR DESCRIPTION
Request to add a new repo related to credo-ts: DIDComm extensions for it.

The repo will be transferred from https://github.com/2060-io/credo-ts-didcomm-ext.